### PR TITLE
Remove MIPS targets from CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,6 @@ jobs:
         aarch64-unknown-linux-gnu
         aarch64-unknown-linux-musl
         powerpc64le-unknown-linux-gnu
-        mipsel-unknown-linux-gnu
-        mips64el-unknown-linux-gnuabi64
         armv5te-unknown-linux-gnueabi
         s390x-unknown-linux-gnu
         arm-linux-androideabi
@@ -108,8 +106,6 @@ jobs:
     - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl --all-targets
     - run: cargo check --workspace --release -vv --target=aarch64-unknown-linux-musl --all-targets
     - run: cargo check --workspace --release -vv --target=powerpc64le-unknown-linux-gnu --all-targets
-    - run: cargo check --workspace --release -vv --target=mipsel-unknown-linux-gnu --all-targets
-    - run: cargo check --workspace --release -vv --target=mips64el-unknown-linux-gnuabi64 --all-targets
     - run: cargo check --workspace --release -vv --target=armv5te-unknown-linux-gnueabi --all-targets
     - run: cargo check --workspace --release -vv --target=s390x-unknown-linux-gnu --all-targets
     - run: cargo check --workspace --release -vv --target=arm-linux-androideabi --all-targets
@@ -125,7 +121,7 @@ jobs:
       QEMU_BUILD_VERSION: 7.0.0
     strategy:
       matrix:
-        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.63, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, mipsel-linux-stable, mips64el-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.63, i686-linux-1.63, aarch64-linux-1.63, riscv64-linux-1.63, s390x-linux-1.63, mipsel-linux-1.63, mips64el-linux-1.63, powerpc64le-linux-1.63, arm-linux-1.63, macos-latest, macos-11]
+        build: [ubuntu, ubuntu-20.04, i686-linux, aarch64-linux, powerpc64le-linux, riscv64-linux, s390x-linux, arm-linux, ubuntu-stable, ubuntu-1.63, i686-linux-stable, aarch64-linux-stable, riscv64-linux-stable, s390x-linux-stable, powerpc64le-linux-stable, arm-linux-stable, ubuntu-1.63, i686-linux-1.63, aarch64-linux-1.63, riscv64-linux-1.63, s390x-linux-1.63, powerpc64le-linux-1.63, arm-linux-1.63, macos-latest, macos-11]
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -167,15 +163,6 @@ jobs:
             qemu: qemu-mips64el
             qemu_args: -L /usr/mips64el-linux-gnuabi64
             qemu_target: mips64el-linux-user
-          - build: mipsel-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: mipsel-unknown-linux-gnu
-            gcc_package: gcc-mipsel-linux-gnu
-            gcc: mipsel-linux-gnu-gcc
-            qemu: qemu-mipsel
-            qemu_args: -L /usr/mipsel-linux-gnu
-            qemu_target: mipsel-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
             rust: nightly
@@ -258,15 +245,6 @@ jobs:
             qemu: qemu-mips64el
             qemu_args: -L /usr/mips64el-linux-gnuabi64
             qemu_target: mips64el-linux-user
-          - build: mipsel-linux-stable
-            os: ubuntu-latest
-            rust: stable
-            target: mipsel-unknown-linux-gnu
-            gcc_package: gcc-mipsel-linux-gnu
-            gcc: mipsel-linux-gnu-gcc
-            qemu: qemu-mipsel
-            qemu_args: -L /usr/mipsel-linux-gnu
-            qemu_target: mipsel-linux-user
           - build: arm-linux-stable
             os: ubuntu-latest
             rust: stable
@@ -331,15 +309,6 @@ jobs:
             qemu: qemu-mips64el
             qemu_args: -L /usr/mips64el-linux-gnuabi64
             qemu_target: mips64el-linux-user
-          - build: mipsel-linux-1.63
-            os: ubuntu-latest
-            rust: 1.63
-            target: mipsel-unknown-linux-gnu
-            gcc_package: gcc-mipsel-linux-gnu
-            gcc: mipsel-linux-gnu-gcc
-            qemu: qemu-mipsel
-            qemu_args: -L /usr/mipsel-linux-gnu
-            qemu_target: mipsel-linux-user
           - build: arm-linux-1.63
             os: ubuntu-latest
             rust: 1.63

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,15 +154,6 @@ jobs:
             qemu: qemu-ppc64le
             qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
-          - build: mips64el-linux
-            os: ubuntu-latest
-            rust: nightly
-            target: mips64el-unknown-linux-gnuabi64
-            gcc_package: gcc-mips64el-linux-gnuabi64
-            gcc: mips64el-linux-gnuabi64-gcc
-            qemu: qemu-mips64el
-            qemu_args: -L /usr/mips64el-linux-gnuabi64
-            qemu_target: mips64el-linux-user
           - build: riscv64-linux
             os: ubuntu-latest
             rust: nightly
@@ -236,15 +227,6 @@ jobs:
             qemu: qemu-ppc64le
             qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
-          - build: mips64el-linux-stable
-            os: ubuntu-latest
-            rust: stable
-            target: mips64el-unknown-linux-gnuabi64
-            gcc_package: gcc-mips64el-linux-gnuabi64
-            gcc: mips64el-linux-gnuabi64-gcc
-            qemu: qemu-mips64el
-            qemu_args: -L /usr/mips64el-linux-gnuabi64
-            qemu_target: mips64el-linux-user
           - build: arm-linux-stable
             os: ubuntu-latest
             rust: stable
@@ -300,15 +282,6 @@ jobs:
             qemu: qemu-ppc64le
             qemu_args: -L /usr/powerpc64le-linux-gnu
             qemu_target: ppc64le-linux-user
-          - build: mips64el-linux-1.63
-            os: ubuntu-latest
-            rust: 1.63
-            target: mips64el-unknown-linux-gnuabi64
-            gcc_package: gcc-mips64el-linux-gnuabi64
-            gcc: mips64el-linux-gnuabi64-gcc
-            qemu: qemu-mips64el
-            qemu_args: -L /usr/mips64el-linux-gnuabi64
-            qemu_target: mips64el-linux-user
           - build: arm-linux-1.63
             os: ubuntu-latest
             rust: 1.63


### PR DESCRIPTION
MIPS targets have moved to Tier 3 in Rust and builds are no longer provided in nightly. rustix-openpty doesn't have any MIPS-specific code, so just disable testing on MIPS.