### PR TITLE
Miscellaneous cleanups.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 rust-version = "1.63"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-rustix = { version = "0.38.0", default-features = false, features = ["fs", "process", "pty", "stdio", "termios"] }
+rustix = { version = "0.38.0", default-features = false, features = ["alloc", "fs", "process", "pty", "stdio", "termios"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 rustix = { version = "0.38.0", default-features = false, features = ["fs", "termios"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub struct Pty {
 ///
 /// On many platforms, this includes a call to [`libc::grantpt`], which has
 /// unspecified behavior if the calling process has a `SIGCHLD` signal handler
-/// installe.
+/// installed.
 ///
 /// # References
 ///  - [Linux]
@@ -49,6 +49,7 @@ pub struct Pty {
 /// [Apple]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/openpty.3.html
 /// [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=openpty&sektion=3
 /// [glibc]: https://www.gnu.org/software/libc/manual/html_node/Pseudo_002dTerminal-Pairs.html#index-openpty
+/// [`libc::grantpt`]: https://docs.rs/libc/latest/libc/fn.grantpt.html
 pub fn openpty(termios: Option<&Termios>, winsize: Option<&Winsize>) -> io::Result<Pty> {
     // On non-Linux platforms, use `libc::openpty`. This doesn't have any way
     // to set `CLOEXEC` so we do it non-atomically.


### PR DESCRIPTION
Fix documentation links, and add the `"alloc"` feature of rustix so that we can call `ptsname`.