### PR TITLE
Add `#![no_std]`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,12 @@
 //! [Linux]: https://man7.org/linux/man-pages/man7/pty.7.html
 //! [FreeBSD]: https://man.freebsd.org/cgi/man.cgi?query=pty&sektion=4
 
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+use alloc::vec::Vec;
 use rustix::fd::{AsFd, OwnedFd};
 #[cfg(any(target_os = "android", target_os = "linux"))] // for `RawDir`
 use rustix::fd::{AsRawFd, RawFd};


### PR DESCRIPTION
This crate doesn't actually need std, and this allows it to be used by c-scape.